### PR TITLE
Ignore zip files.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,23 @@
+# Project specific
+source.datapackage.zip
+fiscal.datapackage.zip
 source.datapackage.json
-pipeline-spec.yaml
-!specifications/source.description.yaml
-!data/FR.france/2014-2020/pipeline-spec.yaml
-logs/
-.idea/
+
+# Extras
+.projectile
+datapackage-pipelines.iml
+celerybeat-schedule
+
+# PyCharm stuff
 .ipynb_checkpoints/
+.idea/
+
+# IOS
 .DS_Store
-source.data.*
+
+# Linux
 .~lock.*
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -85,9 +95,3 @@ target/
 
 # Spyder project settings
 .spyderproject
-
-# Extras
-.projectile
-datapackage-pipelines.iml
-celerybeat-schedule
-/common.plumbing.sandbox/


### PR DESCRIPTION
This commit makes the following changes to .gitignore:
- Ignore zip dumps
- Put pipeline-spec-yaml back into version control
- Clean up the file sub-sections a little

This PR co-fixes #133. ([PR](https://github.com/os-data/eu-structural-funds/pull/138))
