### PR TITLE
Handle currencies by making better use of the JST API.

### DIFF
--- a/common/config.py
+++ b/common/config.py
@@ -50,19 +50,22 @@ UNKNOWN_FIELD_TAG = '_unknown'
 WARNING_CUTOFF = 10
 
 NUMBER_FORMATS = [
-    {'decimalChar': '.', 'groupChar': ','},
-    {'decimalChar': ',', 'groupChar': '.'},
-    # {'decimalChar': '.', 'groupChar': '`'},
-    # {'decimalChar': '.', 'groupChar': '\''},
-    # {'decimalChar': '.', 'groupChar': ' '},
-    # {'decimalChar': ',', 'groupChar': '`'},
-    # {'decimalChar': ',', 'groupChar': '\''},
-    # {'decimalChar': ',', 'groupChar': ' '},
+    {'format': 'currency', 'decimalChar': '.', 'groupChar': ','},
+    {'format': 'currency', 'decimalChar': ',', 'groupChar': '.'},
+    {'format': 'currency', 'decimalChar': '.', 'groupChar': ' '},
+    {'format': 'currency', 'decimalChar': ',', 'groupChar': ' '},
+    {'format': 'currency', 'decimalChar': '.', 'groupChar': ''},
+    {'format': 'currency', 'decimalChar': '.', 'groupChar': '`'},
+    {'format': 'currency', 'decimalChar': ',', 'groupChar': '\''},
+    {'format': 'currency', 'decimalChar': ',', 'groupChar': ' '},
 ]
 
 DATE_FORMATS = [
     {'format': 'fmt:%y'},
     {'format': 'fmt:%Y'},
     {'format': 'fmt:%y-%m-%d'},
-    {'format': 'fmt:%y.%m.%d'}
+    {'format': 'fmt:%Y-%m-%d'},
+    {'format': 'fmt:%y.%m.%d'},
+    {'format': 'fmt:%d.%m.%Y'},
+    {'format': 'fmt:%d.%m.%y'},
 ]

--- a/common/processors/sniff_and_cast.py
+++ b/common/processors/sniff_and_cast.py
@@ -97,11 +97,6 @@ class BaseSniffer(object):
         else:
             return self._guess_caster()
 
-    def cast(self, value):
-        if self.jst_type_class == NumberType:
-            return self._caster.cast_currency(value)
-        return self._caster.cast(value)
-
     def _pre_cast_checks_ok(self, value):
         return True
 

--- a/tests/processors/test_sniff_and_cast.py
+++ b/tests/processors/test_sniff_and_cast.py
@@ -148,10 +148,10 @@ class _BaseGenerator(UserList):
 
 
 class _NumberGenerator(_BaseGenerator):
-    value = 999999.999
+    value = 123456.78
 
     def __str__(self):
-        template = '999{groupChar}999{decimalChar}999'
+        template = '123{groupChar}456{decimalChar}78'
         return template.format(**self.format)
 
 
@@ -259,3 +259,32 @@ def test_pre_and_post_checks_with_corner_cases():
     assert number_sniffer._pre_cast_checks_ok(None)
     assert number_sniffer._post_cast_check_ok(None)
     assert number_sniffer._post_cast_check_ok(1)
+
+
+# Basic casting: dates, numbers and currencies
+# -----------------------------------------------------------------------------
+
+_VALID_RAW_CURRENCIES = [
+    '1090141.18',
+    '€ 1090141.18',
+    '€1090141.18',
+    '1090141.18 €',
+    '1090141.18€',
+    '€ 1,090,141.18',
+]
+
+currency_field = {
+    'name': 'foo',
+    'type': 'number',
+    'decimalChar': '.',
+    'groupChar': ',',
+    'format': 'currency'
+}
+
+currency_sniffer = NumberSniffer(currency_field, sample_resources, 0)
+currency_caster = currency_sniffer.get_caster()
+
+
+@mark.parametrize('value', _VALID_RAW_CURRENCIES)
+def test_number_sniffer_on_values_with_currency_units(value):
+    assert currency_caster.cast(value)


### PR DESCRIPTION
Remove the useless cast method from the BaseSniffer class.  Sniffer objects return a NumberType or a DateType. Their cast method is used instead (it handles currencies too provided 'currency' is passed as a format).  I'm not using the JST API perfectly yet. Instead of DataType and NumberType classes I should be operating one level up with the Field class. I'll do that later.