### PR TITLE
Ensure datapackage<1.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,6 @@ xlrd
 python-slugify
 tabulator>=0.12.1
 requests
-datapackage
+datapackage<1.0
 lxml
 fingerprints


### PR DESCRIPTION
Hi! Frictionless Data's `datapackage-py` is going to reach v1 release and it could be breaking for some software (we use SemVer). Adding `<1.0` version requirement.